### PR TITLE
Host the project directly from project directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@ Shell scripts for quick production deployment of web apps.
 
 ## For Django -
 
-Before everything, make sure you have a requirements.txt file inside your project's root which contains all your dependencies. You might not be able to install dependencies after hosting.
+Before everything, make sure you have a requirements.txt file inside your project's root which contains all your dependencies. 
+(Installing dependencies after hosting is kinda messy.)
 
-1. Clone this repository to your local machine/server
+1. Clone this repository to your local machine/server.
 2. Navigate to django-autohost directory and give host.sh executable permissions by `sudo chmod +x ./host.sh`
 3. Run `sudo ./host.sh <ProjectName> /path/to/project/root/directory "ip_address" "port"`
 
@@ -15,9 +16,8 @@ For example, if I had a project named MyProject at
 
 `sudo ./host.sh MyProject /django/MyProject "localhost" "8080"` (Notice the quotation marks over IP address and port)
 
-This would store hosting-related info with the identifier "MyProject" (yes, it is necessary to use the same name
-as your django project name). After running that command, you will be able to view your website at localhost:8080. Don't
-forget the sudo, this script requires root permissions to place config files in the right directories.
+This would store hosting-related info in a directory with path /autohost/MyProject_hostingdata (yes, it is necessary to use the same name as your django project name). 
+After running that command, you will be able to view your website at localhost:8080. Don't forget the sudo, this script requires root permissions to place config files in the right directories.
 
 #### Note: If you want to host at localhost, make sure you write "localhost" there and not "127.0.0.1". Nginx will have issues if you write 127.0.0.1.
 
@@ -25,9 +25,6 @@ forget the sudo, this script requires root permissions to place config files in 
 This script will use nginx and gunicorn (with 4 process workers) to host your web app. The script is ONLY for hosting, and not for managing your project.
 This means once hosted, you will still need to manage your app. Things like making migrations and collectstatic still need to be 
 done manually (the script will collect static for you once, at the time of running).
-
-When the script completes it's job, you'll be able to find your project at `/srv/<ProjectName>/<ProjectName>`. Only changes there
-will ultimately be reflected on the hosted app.
 
 #### How to "un-host" - 
 To remove your webapp from your server, do the following - 

--- a/django-autohost/host.sh
+++ b/django-autohost/host.sh
@@ -5,88 +5,95 @@ export PROJECT_DIR=$2
 export HOST_IP=$3
 export HOST_PORT=$4
 
-sudo mkdir /srv/$PROJECT_NAME
-sudo mkdir /srv/$PROJECT_NAME/run
-sudo mkdir /srv/$PROJECT_NAME/logs
-sudo touch /srv/$PROJECT_NAME/logs/gunicorn-supervisor.log
-sudo touch /srv/$PROJECT_NAME/logs/nginx-access.log
-sudo touch /srv/$PROJECT_NAME/logs/nginx-error.log
+HOSTING_DIR="/home/autohost/${PROJECT_NAME}_hostingdata"
 
-sudo cp -r $PROJECT_DIR /srv/$PROJECT_NAME
+echo "Saving hosting files at: ${HOSTING_DIR}"
 
-#-------------------------------------------------------------------SETUP GUNICORN--------------------------------------------------------------------
+sudo mkdir -p "$HOSTING_DIR"
+
+sudo chgrp www-data  "$HOSTING_DIR"
+#-------------------------------------------------------SETUP GUNICORN--------------------------------------------------------------------
 
 echo "Setting up gunicorn..."
 
-touch /srv/${PROJECT_NAME}/gunicorn-start.sh
+sudo rm -rf ${HOSTING_DIR}/gunicorn-start.sh
+sudo touch ${HOSTING_DIR}/gunicorn-start.sh
 
-cat >> /srv/${PROJECT_NAME}/gunicorn-start.sh <<\EOF
-#!/bin/bash
+cat >> ${HOSTING_DIR}/gunicorn-start.sh << \EOF
+#!bin/bash
 EOF
 
-cat >> /srv/${PROJECT_NAME}/gunicorn-start.sh <<EOF
-NAME="${PROJECT_NAME}"
-DJANGODIR=/srv/${PROJECT_NAME}/${PROJECT_NAME}
-SOCKFILE=/srv/${PROJECT_NAME}/run/gunicorn.sock
+cat >> ${HOSTING_DIR}/gunicorn-start.sh <<EOF
+NAME=${PROJECT_NAME}
+DJANGODIR=${PROJECT_DIR}
+SOCKFILE=${HOSTING_DIR}/run/gunicorn.sock
 USER=root
-GROUP=webdata
+GROUP=www-data
 NUM_WORKERS=4
 DJANGO_SETTINGS_MODULE=${PROJECT_NAME}.settings
 DJANGO_WSGI_MODULE=${PROJECT_NAME}.wsgi
 EOF
 
-cat >> /srv/${PROJECT_NAME}/gunicorn-start.sh <<\EOF
+cat >> ${HOSTING_DIR}/gunicorn-start.sh <<\EOF
 echo "Starting $NAME as `whoami`"
+EOF
+
+cat >> ${HOSTING_DIR}/gunicorn-start.sh <<EOF
+source ${HOSTING_DIR}/venv/bin/activate
+EOF
+
+cat  >> ${HOSTING_DIR}/gunicorn-start.sh <<\EOF
+echo "Starting $NAME as $(whoami)"
 source /srv/${NAME}/venv/bin/activate
 export DJANGO_SETTINGS_MODULE=$DJANGO_SETTINGS_MODULE
 export PYTHONPATH=$DJANGODIR:$PYTHONPATH
+EOF
 
-RUNDIR=$(dirname $SOCKFILE)
+cat >> ${HOSTING_DIR}/gunicorn-start.sh <<EOF
+RUNDIR=${HOSTING_DIR}/run
+EOF
+
+cat >> ${HOSTING_DIR}/gunicorn-start.sh <<\EOF
 test -d $RUNDIR || mkdir -p $RUNDIR
-
 exec gunicorn ${DJANGO_WSGI_MODULE}:application \
   --name $NAME \
   --workers $NUM_WORKERS \
   --user $USER \
+  --group $GROUP
   --bind=unix:$SOCKFILE
-
 EOF
 
-sudo chmod u+x /srv/$PROJECT_NAME/gunicorn-start.sh
+sudo chmod u+x ${HOSTING_DIR}/gunicorn-start.sh
 
+#-------------------------------------------------------SETUP PROJECT ENVIRONMENT---------------------------------------------------------
+echo "Setting up virtual environment..."
+python3 -m venv "$HOSTING_DIR"/venv
+source "$HOSTING_DIR"/venv/bin/activate
+pip3 install -r "${PROJECT_DIR}"/requirements.txt
+pip3 install gunicorn
 
-
-#---------------------------------------------------------------SETUP PROJECT ENVIRONMENT--------------------------------------------------------------
-
-# cd /srv/$PROJECT_NAME
-python3 -m venv /srv/$PROJECT_NAME/venv
-source /srv/$PROJECT_NAME/venv/bin/activate
-pip install -r /srv/$PROJECT_NAME/$PROJECT_NAME/requirements.txt
-pip install gunicorn
-
-python $PROJECT_NAME/manage.py collectstatic
+python3 "${PROJECT_DIR}"/manage.py collectstatic
 
 deactivate
 
-
-#--------------------------------------------------------------SETUP SERVER-------------------------------------------------------------------------
-
-echo "installing dependencies..."
+#--------------------------------------------------------------SETUP SUPERVISOR----------------------------------------------------------------
+echo "Installing dependencies..."
 sudo apt-get install nginx
 sudo apt-get install supervisor
+
 echo "  "
 
-echo "Setting up supervisor"
-echo $PROJECT_NAME.conf
+echo "Setting up supervisor..."
+echo "$PROJECT_NAME".conf
 
-sudo rm -rf /etc/supervisor/conf.d/$PROJECT_NAME.conf
-touch /etc/supervisor/conf.d/$PROJECT_NAME.conf
+sudo rm -rf /etc/supervisor/conf.d/${PROJECT_NAME}.conf
+sudo touch /etc/supervisor/conf.d/${PROJECT_NAME}.conf
 
-sudo cat >> /etc/supervisor/conf.d/$PROJECT_NAME.conf <<EOF
+sudo cat >> /etc/supervisor/conf.d/${PROJECT_NAME}.conf <<EOF
 [program:$PROJECT_NAME]
-command = /srv/$PROJECT_NAME/gunicorn-start.sh
+command = $GUNICORN_SCRIPT
 user = root
-stdout_logfile = /srv/${PROJECT_NAME}/logs/gunicorn-supervisor.log
+stdout_file = ${HOSTING_DATA_DIR}/logs/gunicorn-supervisor.log
 redirect_stderr = true
 EOF
 
@@ -94,61 +101,62 @@ sudo supervisorctl reread
 sudo supervisorctl update
 
 echo "  "
+
+#--------------------------------------------------------------SETUP NGINX----------------------------------------------------------------
+
 echo "Setting up nginx"
 
+sudo mkdir -p ${HOSTING_DATA_DIR}/logs
+
 sudo rm -rf /etc/nginx/sites-enabled/${PROJECT_NAME}.nginxconf
-touch /etc/nginx/sites-enabled/${PROJECT_NAME}.nginxconf
+sudo touch /etc/nginx/sites-enabled/${PROJECT_NAME}.nginxconf
 
-sudo cat >> /etc/nginx/sites-enabled/$PROJECT_NAME.nginxconf <<EOF
-
+sudo cat >> /etc/nginx/sites-enabled/${PROJECT_NAME}.nginxconf <<EOF
 upstream ${PROJECT_NAME}_app_server {
-  server unix:/srv/${PROJECT_NAME}/run/gunicorn.sock fail_timeout=0;
+server unix:${HOSTING_DATA_DIR}/run/${PROJECT_NAME}.sock fail_timeout=0;
 }
-
 server {
-
-	listen $HOST_PORT;
-	server_name $HOST_IP;
-	
-	client_max_body_size 4G;
-	
-	access_log /srv/${PROJECT_NAME}/logs/nginx-access.log;
-	error_log /srv/${PROJECT_NAME}/logs/nginx-error.log;
-	
-	location /static/ {
-		alias	/srv/$PROJECT_NAME/$PROJECT_NAME/static/;
-	}
-	
-	location /media/ {
-		alias	/srv/$PROJECT_NAME/$PROJECT_NAME/media;
-	}
-EOF
-
-cat >> /etc/nginx/sites-enabled/$PROJECT_NAME.nginxconf <<\EOF
-
-	location / {
-          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-          proxy_set_header Host $http_host;
-
-          proxy_redirect off;
-        if (!-f $request_filename) {
-EOF
-
-cat >> /etc/nginx/sites-enabled/$PROJECT_NAME.nginxconf <<EOF
-
-            proxy_pass http://${PROJECT_NAME}_app_server;
-            break;
-        }
-    }
-
-    # Error pages
-    error_page 500 502 503 504 /500.html;
-    location = /500.html {
-        root ${SCRIPT_PATH}/static/;
-    }
+listen $HOST_PORT;
+server_name $HOST_IP;
+client_max_body_size 4G;
+access_log $HOSTING_DATA_DIR/logs/nginx-access.log;
+error_log $HOSTING_DATA_DIR/logs/nginx-error.log;
+location /static/ {
+alias $PROJECT_DIR/static/;
 }
-
+location /media/ {
+alias $PROJECT_DIR/media/;
+}
 EOF
+
+cat >> /etc/nginx/sites-enabled/${PROJECT_NAME}.nginxconf <<\EOF
+location / {
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header Host $http_host;
+proxy_redirect off;
+if (!-f $request_filename) {
+EOF
+
+cat >> /etc/nginx/sites-enabled/${PROJECT_NAME}.nginxconf <<EOF
+proxy_pass http://${PROJECT_NAME}_app_server;
+break;
+}
+}
+# Error pages
+error_page 500 502 503 504 /500.html;
+location = /500.html {
+root ${PROJECT_DIR}/static/;
+}
+}
+EOF
+
+echo "  "
+
+sudo service nginx restart
+sudo service supervisor restart
+
+echo "  "
+echo "Your django project is online on ${HOST_IP}:${HOST_PORT}"
 
 echo "  "
 echo "Finishing up..."
@@ -158,4 +166,3 @@ sudo service supervisor restart
 
 echo "  "
 echo "Your django project is online on ${HOST_IP}:${HOST_PORT}"
-

--- a/django-autohost/host.sh
+++ b/django-autohost/host.sh
@@ -3,166 +3,153 @@
 export PROJECT_NAME=$1
 export PROJECT_DIR=$2
 export HOST_IP=$3
-export HOST_PORT=$4
+export HOST_ADDRESS=$4
 
-HOSTING_DIR="/home/autohost/${PROJECT_NAME}_hostingdata"
+echo "Running autohost on ${PROJECT_NAME}..."
 
-echo "Saving hosting files at: ${HOSTING_DIR}"
+#------
+HOSTING_DIR="/autohost/${PROJECT_NAME}_hostingdata"
+echo "Saving hosting data in ${HOSTING_DIR}"
 
-sudo mkdir -p "$HOSTING_DIR"
+sudo rm -rf $HOSTING_DIR
+sudo mkdir -p $HOSTING_DIR
+sudo mkdir "${HOSTING_DIR}/logs"
+sudo touch $HOSTING_DIR/logs/gunicorn-supervisor.log
+sudo touch $HOSTING_DIR/logs/nginx-access.log
+sudo touch $HOSTING_DIR/logs/nginx-error.log
 
-sudo chgrp www-data  "$HOSTING_DIR"
-#-------------------------------------------------------SETUP GUNICORN--------------------------------------------------------------------
+#------
+echo "Setting up Gunicorn..."
+GUNICORN_SCRIPT="${HOSTING_DIR}/gunicorn-start.sh"
 
-echo "Setting up gunicorn..."
+sudo touch $GUNICORN_SCRIPT
 
-sudo rm -rf ${HOSTING_DIR}/gunicorn-start.sh
-sudo touch ${HOSTING_DIR}/gunicorn-start.sh
-
-cat >> ${HOSTING_DIR}/gunicorn-start.sh << \EOF
-#!bin/bash
+cat >> $GUNICORN_SCRIPT <<\EOF
+#!/bin/bash
 EOF
 
-cat >> ${HOSTING_DIR}/gunicorn-start.sh <<EOF
-NAME=${PROJECT_NAME}
-DJANGODIR=${PROJECT_DIR}
-SOCKFILE=${HOSTING_DIR}/run/gunicorn.sock
+cat >> $GUNICORN_SCRIPT <<EOF
+NAME="${PROJECT_NAME}"
+SOCKFILE="${HOSTING_DIR}/run/gunicorn.sock"
 USER=root
-GROUP=www-data
+GROUP=webapps
 NUM_WORKERS=4
 DJANGO_SETTINGS_MODULE=${PROJECT_NAME}.settings
 DJANGO_WSGI_MODULE=${PROJECT_NAME}.wsgi
 EOF
 
-cat >> ${HOSTING_DIR}/gunicorn-start.sh <<\EOF
-echo "Starting $NAME as `whoami`"
+cat >> $GUNICORN_SCRIPT <<\EOF
+echo "Starting ${NAME} as root"
 EOF
 
-cat >> ${HOSTING_DIR}/gunicorn-start.sh <<EOF
-source ${HOSTING_DIR}/venv/bin/activate
+cat >> $GUNICORN_SCRIPT <<EOF
+source "${HOSTING_DIR}/venv/bin/activate"
 EOF
 
-cat  >> ${HOSTING_DIR}/gunicorn-start.sh <<\EOF
-echo "Starting $NAME as $(whoami)"
-source /srv/${NAME}/venv/bin/activate
+cat >> $GUNICORN_SCRIPT <<\EOF
 export DJANGO_SETTINGS_MODULE=$DJANGO_SETTINGS_MODULE
 export PYTHONPATH=$DJANGODIR:$PYTHONPATH
-EOF
 
-cat >> ${HOSTING_DIR}/gunicorn-start.sh <<EOF
-RUNDIR=${HOSTING_DIR}/run
-EOF
+RUNDIR="${HOSTING_DIR}/run"
+mkdir -p $RUNDIR
 
-cat >> ${HOSTING_DIR}/gunicorn-start.sh <<\EOF
-test -d $RUNDIR || mkdir -p $RUNDIR
 exec gunicorn ${DJANGO_WSGI_MODULE}:application \
-  --name $NAME \
-  --workers $NUM_WORKERS \
-  --user $USER \
-  --group $GROUP
-  --bind=unix:$SOCKFILE
+	--name $NAME
+	--workers $NUM_WORKERS
+	--user=$USER --group=$GROUP
+	--bind=unix:$SOCKFILE
+
 EOF
 
-sudo chmod u+x ${HOSTING_DIR}/gunicorn-start.sh
+sudo chmod u+x $GUNICORN_SCRIPT
 
-#-------------------------------------------------------SETUP PROJECT ENVIRONMENT---------------------------------------------------------
-echo "Setting up virtual environment..."
-python3 -m venv "$HOSTING_DIR"/venv
-source "$HOSTING_DIR"/venv/bin/activate
-pip3 install -r "${PROJECT_DIR}"/requirements.txt
-pip3 install gunicorn
 
-python3 "${PROJECT_DIR}"/manage.py collectstatic
+#------
+python3 -m venv "${HOSTING_DIR}/venv"
+source "${HOSTING_DIR}/venv/bin/activate"
+
+pip install -r "${PROJECT_DIR}/requirements.txt"
+pip install gunicorn
+pip install setproctitle
+
+python "${PROJECT_DIR}/manage.py" collectstatic
 
 deactivate
 
-#--------------------------------------------------------------SETUP SUPERVISOR----------------------------------------------------------------
-echo "Installing dependencies..."
+#-----
+echo "Installing dependencies"
 sudo apt-get install nginx
 sudo apt-get install supervisor
 
-echo "  "
+echo "	"
+echo "Setting up supervisor"
+echo "${PROJECT_NAME}.conf"
 
-echo "Setting up supervisor..."
-echo "$PROJECT_NAME".conf
-
-sudo rm -rf /etc/supervisor/conf.d/${PROJECT_NAME}.conf
-sudo touch /etc/supervisor/conf.d/${PROJECT_NAME}.conf
-
-sudo cat >> /etc/supervisor/conf.d/${PROJECT_NAME}.conf <<EOF
-[program:$PROJECT_NAME]
-command = $GUNICORN_SCRIPT
+sudo cat >> "/etc/supervisor/conf.d/${PROJECT_NAME}.conf" <<EOF
+[program:${PROJECT_NAME}]
+command = ${HOSTING_DIR}/gunicorn-start.sh
 user = root
-stdout_file = ${HOSTING_DATA_DIR}/logs/gunicorn-supervisor.log
-redirect_stderr = true
+stdout_logfile = $HOSTING_DIR/logs/gunicorn-supervisor.log
+redirect_stderror = true
 EOF
 
 sudo supervisorctl reread
 sudo supervisorctl update
 
-echo "  "
-
-#--------------------------------------------------------------SETUP NGINX----------------------------------------------------------------
-
+echo "	"
 echo "Setting up nginx"
 
-sudo mkdir -p ${HOSTING_DATA_DIR}/logs
-
 sudo rm -rf /etc/nginx/sites-enabled/${PROJECT_NAME}.nginxconf
-sudo touch /etc/nginx/sites-enabled/${PROJECT_NAME}.nginxconf
+touch /etc/nginx/sites-enabled/${PROJECT_NAME}.nginxconf
 
 sudo cat >> /etc/nginx/sites-enabled/${PROJECT_NAME}.nginxconf <<EOF
 upstream ${PROJECT_NAME}_app_server {
-server unix:${HOSTING_DATA_DIR}/run/${PROJECT_NAME}.sock fail_timeout=0;
+	server unix:${HOSTING_DIR}/run/gunicorn.sock fail_timeout=0;
 }
+
+
 server {
-listen $HOST_PORT;
-server_name $HOST_IP;
-client_max_body_size 4G;
-access_log $HOSTING_DATA_DIR/logs/nginx-access.log;
-error_log $HOSTING_DATA_DIR/logs/nginx-error.log;
-location /static/ {
-alias $PROJECT_DIR/static/;
-}
-location /media/ {
-alias $PROJECT_DIR/media/;
+	listen $HOST_PORT;
+	server_name $HOST_IP;
+	
+	client_max_body_size 4G;
+	
+	access_log ${HOSTING_DIR}/logs/nginx-access.log;
+	error_log ${HOSTING_DIR}/logs/nginx-error.log;
+	
+	location /static/ {
+		alias	$PROJECT_DIR/static/;
+	}
+	
+	location /media/ {
+		alias	$PROJECT_DIR/media;
+	}
+EOF
+cat >> /etc/nginx/sites-enabled/$PROJECT_NAME.nginxconf <<\EOF
+	location / {
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header Host $http_host;
+          proxy_redirect off;
+        if (!-f $request_filename) {
+EOF
+
+cat >> /etc/nginx/sites-enabled/$PROJECT_NAME.nginxconf <<EOF
+            proxy_pass http://${PROJECT_NAME}_app_server;
+            break;
+        }
+    }
+    # Error pages
+    error_page 500 502 503 504 /500.html;
+    location = /500.html {
+        root ${PROJECT_DIR}/static/;
+	    }
 }
 EOF
 
-cat >> /etc/nginx/sites-enabled/${PROJECT_NAME}.nginxconf <<\EOF
-location / {
-proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-proxy_set_header Host $http_host;
-proxy_redirect off;
-if (!-f $request_filename) {
-EOF
+sudo service restart nginx
+sudo service restart supervisor
 
-cat >> /etc/nginx/sites-enabled/${PROJECT_NAME}.nginxconf <<EOF
-proxy_pass http://${PROJECT_NAME}_app_server;
-break;
-}
-}
-# Error pages
-error_page 500 502 503 504 /500.html;
-location = /500.html {
-root ${PROJECT_DIR}/static/;
-}
-}
-EOF
+echo "Your project is up and running at ${HOST_IP}:${HOST_PORT}"
 
-echo "  "
 
-sudo service nginx restart
-sudo service supervisor restart
 
-echo "  "
-echo "Your django project is online on ${HOST_IP}:${HOST_PORT}"
-
-echo "  "
-echo "Finishing up..."
-
-sudo service nginx restart
-sudo service supervisor restart
-
-echo "  "
-echo "Your django project is online on ${HOST_IP}:${HOST_PORT}"

--- a/django-autohost/host.sh
+++ b/django-autohost/host.sh
@@ -94,7 +94,7 @@ sudo cat >> "/etc/supervisor/conf.d/${PROJECT_NAME}.conf" <<EOF
 [program:${PROJECT_NAME}]
 command=${GUNICORN_SCRIPT}
 user = root
-stdout_logfile = $HOSTING_DIR/logs/gunicorn-supervisor.log
+stdout_logfile = "${HOSTING_DIR}/logs/gunicorn-supervisor.log"
 redirect_stderror = true
 EOF
 
@@ -103,7 +103,7 @@ sudo supervisorctl update
 
 echo "	"
 echo "Setting up nginx"
-
+echo "Saving nginx configuration at /etc/nginx/sites-available/${PROJECT_NAME}"
 sudo rm -rf /etc/nginx/sites-available/${PROJECT_NAME}
 sudo rm -rf /etc/nginx/sites-enabled/${PROJECT_NAME}
 touch /etc/nginx/sites-available/${PROJECT_NAME}
@@ -153,8 +153,11 @@ cat >> /etc/nginx/sites-available/$PROJECT_NAME <<EOF
 EOF
 
 sudo ln -s /etc/nginx/sites-available/${PROJECT_NAME} /etc/nginx/sites-enabled/
-service restart nginx
-service restart supervisor
+
+sudo nginx -s reload
+sudo nginx -s reopen
+sudo supervisorctl status $PROJECT_NAME
+
 
 echo "Your project is up and running at ${HOST_IP}:${HOST_PORT}"
 

--- a/django-autohost/host.sh
+++ b/django-autohost/host.sh
@@ -14,9 +14,9 @@ echo "Saving hosting data in ${HOSTING_DIR}"
 sudo rm -rf $HOSTING_DIR
 sudo mkdir -p $HOSTING_DIR
 sudo mkdir "${HOSTING_DIR}/logs"
-sudo touch $HOSTING_DIR/logs/gunicorn-supervisor.log
-sudo touch $HOSTING_DIR/logs/nginx-access.log
-sudo touch $HOSTING_DIR/logs/nginx-error.log
+sudo touch "$HOSTING_DIR/logs/gunicorn-supervisor.log"
+sudo touch "$HOSTING_DIR/logs/nginx-access.log"
+sudo touch "$HOSTING_DIR/logs/nginx-error.log"
 
 #------
 echo "Setting up Gunicorn..."
@@ -49,16 +49,19 @@ EOF
 cat >> $GUNICORN_SCRIPT <<\EOF
 export DJANGO_SETTINGS_MODULE=$DJANGO_SETTINGS_MODULE
 export PYTHONPATH=$DJANGODIR:$PYTHONPATH
+EOF
 
-RUNDIR="${HOSTING_DIR}/run"
-mkdir -p $RUNDIR
+cat >> $GUNICORN_SCRIPT <<EOF
+mkdir -p ${GUNICORN_SCRIPT} <<EOF
 
+EOF
+
+cat >> $GUNICORN_SCRIPT <<\EOF
 exec gunicorn ${DJANGO_WSGI_MODULE}:application \
-	--name $NAME
-	--workers $NUM_WORKERS
-	--user=$USER --group=$GROUP
-	--bind=unix:$SOCKFILE
-
+	--name $NAME \
+	--workers $NUM_WORKERS \
+	--user=$USER --group=$GROUP \
+	--bind=unix:$SOCKFILE 
 EOF
 
 sudo chmod u+x $GUNICORN_SCRIPT
@@ -109,8 +112,8 @@ upstream ${PROJECT_NAME}_app_server {
 
 
 server {
-	listen $HOST_PORT;
-	server_name $HOST_IP;
+	listen ${HOST_PORT};
+	server_name ${HOST_IP};
 	
 	client_max_body_size 4G;
 	

--- a/django-autohost/remove.sh
+++ b/django-autohost/remove.sh
@@ -1,9 +1,13 @@
 export PROJECT_NAME=$1
 
-echo "Removing all traces of your website..."
+echo "Unhosting your website..."
 
-sudo rm -rf /srv/$PROJECT_NAME
-sudo rm -rf /etc/nginx/sites-enabled/${PROJECT_NAME}.nginxconf
-sudo rm -rf /etc/supervisor/conf.d/${PROJECT_NAME}.conf
+echo "Removing hosting files..."
+sudo rm -rf "/autohost/${PROJECT_NAME}_hostingdata"
+echo "Removing nginx configurations..."
+sudo rm -rf "/etc/nginx/sites-enabled/${PROJECT_NAME}"
+sudo rm -rf "/etc/nginx/sites-available/${PROJECT_NAME}"
+echo "Removing supervisor program..."
+sudo rm -rf "/etc/supervisor/conf.d/${PROJECT_NAME}.conf"
 
 echo "Done"


### PR DESCRIPTION
- No longer copies the project into /srv/
- Changes in your project will be reflected without having to "rehost" or copy again
- Files related to hosting are stored in a directory with path /autohost/<project_name>_hostingdata
- Site config is stored in sites-available with a symlink to sites-enabled rather than sites-enabled directly
- Gunicorn processes are given a title with "setproctitle" (Note: You need a gcc for this)